### PR TITLE
RHDHPAI-505: Switch the entity provider to the model catalog bridge

### DIFF
--- a/workspaces/rhdh-ai/README.md
+++ b/workspaces/rhdh-ai/README.md
@@ -19,6 +19,12 @@ yarn backstage-repo-tools knip-reports
 
 To run the rhdh-ai backend module in development mode:
 
-1. Run `yarn install` to install dependencies
+1. Ensure the following environment variables are set:
 
-2. Run `yarn dev` to launch the module
+- `RHDH_AI_BRIDGE_SERVER`: Set to the server hosting the RHDH AI Bridge
+- `RHDH_BRIDGE_HOST`: Similar as above, but without the protocol
+- `RHDH_TOKEN`: Any 8 character password to use for authentication with RHDH
+
+2. Run `yarn install` to install dependencies
+
+3. Run `yarn dev` to launch the module

--- a/workspaces/rhdh-ai/app-config.yaml
+++ b/workspaces/rhdh-ai/app-config.yaml
@@ -91,6 +91,5 @@ catalog:
   providers:
     modelCatalog:
       ollama:
-        baseUrl: '${RHDH_AI_MODEL_SERVER}'
-        authorization: '${RHDH_AI_AUTH_TOKEN}'
+        baseUrl: '${RHDH_AI_BRIDGE_SERVER}'
         name: 'Ollama Model Service'

--- a/workspaces/rhdh-ai/plugins/catalog-backend-module-rhdh-ai/config.d.ts
+++ b/workspaces/rhdh-ai/plugins/catalog-backend-module-rhdh-ai/config.d.ts
@@ -24,8 +24,6 @@ export interface Config {
            * ModelCatalogConfig
            */
           baseUrl: string;
-          /** @visibility secret */
-          authorization: string;
           name?: string;
           system?: string;
           owner?: string;

--- a/workspaces/rhdh-ai/plugins/catalog-backend-module-rhdh-ai/package.json
+++ b/workspaces/rhdh-ai/plugins/catalog-backend-module-rhdh-ai/package.json
@@ -28,7 +28,8 @@
     "@backstage/catalog-model": "^1.7.2",
     "@backstage/errors": "^1.2.7",
     "@backstage/plugin-catalog-common": "^1.1.3",
-    "@backstage/plugin-catalog-node": "^1.15.1"
+    "@backstage/plugin-catalog-node": "^1.15.1",
+    "yaml": "^2.7.0"
   },
   "devDependencies": {
     "@backstage/backend-test-utils": "^1.2.1",

--- a/workspaces/rhdh-ai/plugins/catalog-backend-module-rhdh-ai/src/clients/BridgeResourceConnector.ts
+++ b/workspaces/rhdh-ai/plugins/catalog-backend-module-rhdh-ai/src/clients/BridgeResourceConnector.ts
@@ -13,8 +13,12 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import { ModelList } from './types';
+import { Entity } from '@backstage/catalog-model';
 
+import YAML from 'yaml';
+
+// listModels will list the models from an OpenAI compatible endpoint
+/*
 export async function listModels(
   baseUrl: string,
   access_token: string,
@@ -32,5 +36,24 @@ export async function listModels(
   }
 
   const data = await res.json();
+  return data;
+}*/
+
+export async function fetchCatalogEntities(baseUrl: string): Promise<Entity[]> {
+  // ToDo: Discover catalog-info endpoint?
+  const res = await fetch(`${baseUrl}/mnist/v1/catalog-info.yaml`, {
+    method: 'GET',
+  });
+
+  if (!res.ok) {
+    throw new Error(res.statusText);
+  }
+
+  // ToDo: Look at seeing if we can use the parser provided by the CatalogProcessorProvider package
+  const data = await res
+    .blob()
+    .then(blob => blob.text())
+    .then(yamlStr => YAML.parseAllDocuments(yamlStr))
+    .then(yamlData => yamlData.map(item => item.toJS()));
   return data;
 }

--- a/workspaces/rhdh-ai/plugins/catalog-backend-module-rhdh-ai/src/clients/index.ts
+++ b/workspaces/rhdh-ai/plugins/catalog-backend-module-rhdh-ai/src/clients/index.ts
@@ -13,4 +13,4 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-export * from './OpenAIResourceConnector';
+export * from './BridgeResourceConnector';

--- a/workspaces/rhdh-ai/plugins/catalog-backend-module-rhdh-ai/src/providers/config.ts
+++ b/workspaces/rhdh-ai/plugins/catalog-backend-module-rhdh-ai/src/providers/config.ts
@@ -39,10 +39,6 @@ function readModelCatalogApiEntityConfig(
   config: Config,
 ): ModelCatalogConfig {
   const baseUrl = config.getString('baseUrl');
-  const authorization = config.getString('authorization');
-  const name = config.getString('name');
-  const system = config.getOptionalString('system');
-  const owner = config.getOptionalString('owner') ?? 'unknown';
 
   const schedule = config.has('schedule')
     ? readSchedulerServiceTaskScheduleDefinitionFromConfig(
@@ -53,10 +49,6 @@ function readModelCatalogApiEntityConfig(
   return {
     id,
     baseUrl,
-    authorization,
-    name,
-    system,
-    owner,
     schedule,
   };
 }

--- a/workspaces/rhdh-ai/plugins/catalog-backend-module-rhdh-ai/src/providers/types.ts
+++ b/workspaces/rhdh-ai/plugins/catalog-backend-module-rhdh-ai/src/providers/types.ts
@@ -18,9 +18,5 @@ import type { SchedulerServiceTaskScheduleDefinition } from '@backstage/backend-
 export type ModelCatalogConfig = {
   id: string;
   baseUrl: string;
-  authorization: string;
-  name: string;
-  owner: string;
-  system?: string;
   schedule?: SchedulerServiceTaskScheduleDefinition;
 };

--- a/workspaces/rhdh-ai/yarn.lock
+++ b/workspaces/rhdh-ai/yarn.lock
@@ -10177,6 +10177,7 @@ __metadata:
     "@backstage/errors": ^1.2.7
     "@backstage/plugin-catalog-common": ^1.1.3
     "@backstage/plugin-catalog-node": ^1.15.1
+    yaml: ^2.7.0
   languageName: unknown
   linkType: soft
 
@@ -34105,7 +34106,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"yaml@npm:^2.0.0, yaml@npm:^2.0.0-10, yaml@npm:^2.2.1, yaml@npm:^2.2.2":
+"yaml@npm:^2.0.0, yaml@npm:^2.0.0-10, yaml@npm:^2.2.1, yaml@npm:^2.2.2, yaml@npm:^2.7.0":
   version: 2.7.0
   resolution: "yaml@npm:2.7.0"
   bin:


### PR DESCRIPTION
Updates the entity provider PoC to call the model catalog bridge endpoint on Backstage start up, rather than the OpenAI endpoint used previously. The OpenAI endpoint code has been left in place, but commented out, should we wish to revisit it later. Currently this pulls in the default yaml parser provided by node, but a discussion with @gabemontero from earlier today suggested it may be possible to use the built-in `CatalogProcessorParser` provided by Backstage.

To test out my changes:
1) Check out https://github.com/gabemontero/rhdh-ai-catalog-cli/tree/http-endpoint-for-import
2) Navigate to `assets/bridge/` and run `kubectl apply -f .` to deploy the Bridge HTTP service
3) Run `oc get routes` to fetch the route URL for the bridge
4) Set the following environment variables:
    - `RHDH_AI_BRIDGE_SERVER`: Set to the server hosting the RHDH AI Bridge
    - `RHDH_BRIDGE_HOST`: Similar as above, but without the protocol (http/https)
    - `RHDH_TOKEN`: Any 8 character password to use for authentication with RHDH
5) Navigate to my branch's `workspace/rhdh-ai` folder
6) `yarn install`
7) `yarn dev`)

## Hey, I just made a Pull Request!

<!-- Please describe what you added, and add a screenshot if possible.
     That makes it easier to understand the change so we can :shipit: faster. -->

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [ ] A changeset describing the change and affected packages. ([more info](https://github.com/redhat-developer/rhdh-plugins/blob/main/CONTRIBUTING.md#creating-changesets))
- [ ] Added or Updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
