### PR TITLE
RHDHPAI-506: add entity provider that uses catalog REST API to fetch bridge locations, refetch from bridge, and apply deltas/patches

### DIFF
--- a/workspaces/rhdh-ai/app-config.yaml
+++ b/workspaces/rhdh-ai/app-config.yaml
@@ -41,7 +41,8 @@ backend:
     allow:
       - host: example.com
       - host: '*.mozilla.org'
-      - host: '${RHDH_BRIDGE_HOST}'
+      - host: '*.openshift.com'
+      - host: '*.openshiftapps.com'
 
 integrations:
   github:

--- a/workspaces/rhdh-ai/packages/backend/src/index.ts
+++ b/workspaces/rhdh-ai/packages/backend/src/index.ts
@@ -18,6 +18,7 @@ import { createBackend } from '@backstage/backend-defaults';
 import {
   catalogModuleRHDHRHOAIReaderProcessor,
   catalogModuleRHDHRHOAILocationsExtensionPoint,
+  catalogModuleRHDHRHOAIEntityProvider,
 } from '@red-hat-developer-hub/backstage-plugin-catalog-backend-module-rhdh-ai';
 
 const backend = createBackend();
@@ -69,4 +70,5 @@ backend.add(
 );
 backend.add(catalogModuleRHDHRHOAILocationsExtensionPoint);
 backend.add(catalogModuleRHDHRHOAIReaderProcessor);
+backend.add(catalogModuleRHDHRHOAIEntityProvider);
 backend.start();

--- a/workspaces/rhdh-ai/plugins/catalog-backend-module-rhdh-ai/package.json
+++ b/workspaces/rhdh-ai/plugins/catalog-backend-module-rhdh-ai/package.json
@@ -25,8 +25,10 @@
   },
   "dependencies": {
     "@backstage/backend-plugin-api": "^1.1.1",
+    "@backstage/catalog-client": "^1.9.1",
     "@backstage/catalog-model": "^1.7.2",
     "@backstage/errors": "^1.2.7",
+    "@backstage/plugin-catalog-backend": "^1.30.0",
     "@backstage/plugin-catalog-common": "^1.1.3",
     "@backstage/plugin-catalog-node": "^1.15.1",
     "yaml": "^2.7.0"

--- a/workspaces/rhdh-ai/plugins/catalog-backend-module-rhdh-ai/src/clients/BridgeResourceConnector.ts
+++ b/workspaces/rhdh-ai/plugins/catalog-backend-module-rhdh-ai/src/clients/BridgeResourceConnector.ts
@@ -41,7 +41,7 @@ export async function listModels(
 
 export async function fetchCatalogEntities(baseUrl: string): Promise<Entity[]> {
   // ToDo: Discover catalog-info endpoint?
-  const res = await fetch(`${baseUrl}/mnist/v1/catalog-info.yaml`, {
+  const res = await fetch(`${baseUrl}`, {
     method: 'GET',
   });
 

--- a/workspaces/rhdh-ai/plugins/catalog-backend-module-rhdh-ai/src/index.ts
+++ b/workspaces/rhdh-ai/plugins/catalog-backend-module-rhdh-ai/src/index.ts
@@ -24,6 +24,7 @@
 export { catalogModuleModelCatalogResourceEntityProvider as default } from './module';
 export { catalogModuleRHDHRHOAIReaderProcessor } from './module';
 export { catalogModuleRHDHRHOAILocationsExtensionPoint } from './module';
+export { catalogModuleRHDHRHOAIEntityProvider } from './module';
 export * from './providers';
 export * from './processors';
 export * from './clients';

--- a/workspaces/rhdh-ai/plugins/catalog-backend-module-rhdh-ai/src/providers/RHDHRHOAIEntityProvider.ts
+++ b/workspaces/rhdh-ai/plugins/catalog-backend-module-rhdh-ai/src/providers/RHDHRHOAIEntityProvider.ts
@@ -1,0 +1,207 @@
+/*
+ * Copyright Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import type {
+  DiscoveryService,
+  LoggerService,
+  RootConfigService,
+  SchedulerServiceTaskRunner,
+  UrlReaderService,
+} from '@backstage/backend-plugin-api';
+import { LocationEntity } from '@backstage/catalog-model';
+import {
+  EntityProvider,
+  EntityProviderConnection,
+  CatalogProcessorParser,
+  CatalogProcessorEntityResult,
+} from '@backstage/plugin-catalog-node';
+import {
+  CatalogApi,
+  CatalogClient,
+  CatalogRequestOptions,
+} from '@backstage/catalog-client';
+import { isError } from '@backstage/errors';
+import { parseEntityYaml } from '@backstage/plugin-catalog-backend';
+import { ModelCatalogConfig } from './types';
+import { readModelCatalogApiEntityConfigs } from './config';
+/**
+ * Provides entities from the model catalog service, allowing models and model servers to be imported into RHDH
+ */
+export class RHDHRHOAIEntityProvider implements EntityProvider {
+  private readonly catalogClient: CatalogApi;
+  private readonly logger: LoggerService;
+  private readonly scheduleFn: () => Promise<void>;
+  private connection?: EntityProviderConnection;
+  private readonly reader: UrlReaderService;
+  private readonly token: string;
+  private readonly modelCatalogConfigs: ModelCatalogConfig[];
+
+  /** [1]: Set configuration values passed into the entity provider. Fields are defined in types.ts */
+  constructor(
+    discovery: DiscoveryService,
+    config: RootConfigService,
+    logger: LoggerService,
+    taskRunner: SchedulerServiceTaskRunner,
+    reader: UrlReaderService,
+  ) {
+    this.reader = reader;
+    this.catalogClient = new CatalogClient({ discoveryApi: discovery });
+    this.logger = logger.child({
+      target: this.getProviderName(),
+    });
+    this.scheduleFn = this.createScheduleFn(taskRunner);
+    const authConfigs =
+      config.getOptionalConfigArray('backend.auth.externalAccess') ?? [];
+    this.token = '';
+    for (const authConfig of authConfigs) {
+      const type = authConfig.getString('type');
+      const subject = authConfig.getString('options.subject');
+      // TODO make this name something RHDH bridge specific
+      if (type === 'static' && subject === 'admin-curl-access') {
+        this.token = authConfig.getString('options.token');
+        break;
+      }
+    }
+    this.modelCatalogConfigs = readModelCatalogApiEntityConfigs(config);
+  }
+
+  /** Configure the schedule function and its logger */
+  createScheduleFn(
+    taskRunner: SchedulerServiceTaskRunner,
+  ): () => Promise<void> {
+    return async () => {
+      const taskId = `${this.getProviderName()}:run`;
+      return taskRunner.run({
+        id: taskId,
+        fn: async () => {
+          try {
+            await this.run();
+          } catch (error) {
+            if (isError(error)) {
+              // Ensure that we don't log any sensitive internal data:
+              this.logger.error(
+                `Error while syncing resources from RHDH RHOAI bridge}`,
+                {
+                  // Default Error properties:
+                  name: error.name,
+                  message: error.message,
+                  stack: error.stack,
+                  // Additional status code if available:
+                  status: (error.response as { status?: string })?.status,
+                },
+              );
+            }
+          }
+        },
+      });
+    };
+  }
+
+  /** [2]: Model Catalog entity provider must have a unique name */
+  getProviderName(): string {
+    return `RHDHRHOAIEntityProvider`;
+  }
+
+  /** [3]: Connect Backstage catalog engine to ModelCatalogEntityProvider */
+  async connect(connection: EntityProviderConnection): Promise<void> {
+    this.connection = connection;
+    await this.scheduleFn();
+  }
+
+  // the defaultEntityDataParser from backstage's catalog-backend module is not exported (though the parseEntityYaml from the same file is)
+  // so we are replicating the small function they have there
+  defaultEntityDataParser: CatalogProcessorParser =
+    async function* defaultEntityDataParser({ data, location }) {
+      for (const e of parseEntityYaml(data, location)) {
+        yield e;
+      }
+    };
+
+  /** [4]: Define the function that the entity provider will execute on a set schedule */
+  async run(): Promise<void> {
+    if (!this.connection) {
+      throw new Error('Not initialized');
+    }
+    this.logger.info(`Checking RHDH/RHOAI Locations`);
+
+    const filter: Record<string, string> = {
+      kind: 'location',
+    };
+    const options: CatalogRequestOptions = {
+      token: this.token,
+    };
+
+    const { items } = await this.catalogClient.getEntities({ filter }, options);
+    if (items.length === 0) {
+      return;
+    }
+    for (const item of items) {
+      const loc = item as LocationEntity;
+      let startUpLocation = false;
+      if (loc.spec.type === 'rhdh-rhoai-bridge') {
+        for (const config of this.modelCatalogConfigs) {
+          if (config.baseUrl === loc.spec.target) {
+            startUpLocation = true;
+            break;
+          }
+        }
+        if (startUpLocation) {
+          this.logger.info(
+            `RHDHRHOAIEntityProvider skipping ${loc.spec.target} because if is handled by ModelCatalogEntityProvider`,
+          );
+          continue;
+        }
+        try {
+          const locationURL = loc.spec.target as string;
+          const data = await this.reader.readUrl(locationURL);
+          const response = [
+            { url: loc.spec.target, data: await data.buffer() },
+          ];
+          for (const resp of response) {
+            if (resp.url !== undefined) {
+              for await (const parseResult of this.defaultEntityDataParser({
+                data: resp.data,
+                location: { type: loc.spec.type, target: resp.url },
+              })) {
+                const resultEntity =
+                  parseResult as CatalogProcessorEntityResult;
+                const locType = loc.spec.type;
+                const locTarget = loc.spec.target;
+                const locKey = `${locType}:${locTarget}`;
+                const deferredEntity = {
+                  entity: resultEntity.entity,
+                  locationKey: locKey,
+                };
+                await this.connection.applyMutation({
+                  type: 'delta',
+                  added: [deferredEntity],
+                  removed: [],
+                });
+              }
+            }
+          }
+        } catch (error) {
+          const deferredEntity = { entity: item };
+          await this.connection.applyMutation({
+            type: 'delta',
+            added: [],
+            removed: [deferredEntity],
+          });
+        }
+      }
+    }
+  }
+}

--- a/workspaces/rhdh-ai/yarn.lock
+++ b/workspaces/rhdh-ai/yarn.lock
@@ -10172,9 +10172,11 @@ __metadata:
   dependencies:
     "@backstage/backend-plugin-api": ^1.1.1
     "@backstage/backend-test-utils": ^1.2.1
+    "@backstage/catalog-client": ^1.9.1
     "@backstage/catalog-model": ^1.7.2
     "@backstage/cli": ^0.29.5
     "@backstage/errors": ^1.2.7
+    "@backstage/plugin-catalog-backend": ^1.30.0
     "@backstage/plugin-catalog-common": ^1.1.3
     "@backstage/plugin-catalog-node": ^1.15.1
     yaml: ^2.7.0


### PR DESCRIPTION

## Hey, I just made a Pull Request!

An entity provider that does not need an app-config.yaml snippet like 
```
catalog:
  providers:
    modelCatalog:
      ollama:
        baseUrl: '${RHDH_AI_BRIDGE_SERVER}'
        name: 'Ollama Model Service'
```
But can poll for locations from unregistered (in the RHDH config) bridges, where they in theory have a domain that matches an allowed host domain in the app-config.yaml

So when those unregistered model catalog bridges create locations et. al. and then on its polling interval:
- queries the catalog REST API using our admin-curl-token from $RHDH_TOKEN
- then for any locations imported by the bridge (and only those)
- fetches the content from the bridge
- cycles through the entities and applies delta patch mutations
- now, if there was an error fetching from the bridge, it then deletes the location (certainly a productized version of this would some form of retry and min number of failures needed to delete)


#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [ ] A changeset describing the change and affected packages. ([more info](https://github.com/redhat-developer/rhdh-plugins/blob/main/CONTRIBUTING.md#creating-changesets))
- [ ] Added or Updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
