### PR TITLE
RHDHPAI-641: add locations to entities pushed from the bridge

### DIFF
--- a/workspaces/rhdh-ai/plugins/catalog-backend-module-rhdh-ai/src/processors/RHDHRHOAIReaderProcessor.ts
+++ b/workspaces/rhdh-ai/plugins/catalog-backend-module-rhdh-ai/src/processors/RHDHRHOAIReaderProcessor.ts
@@ -30,6 +30,10 @@ import { LocationSpec } from '@backstage/plugin-catalog-common';
 
 import { ModelCatalogConfig } from '../providers/types';
 import { readModelCatalogApiEntityConfigs } from '../providers/config';
+import {
+  ANNOTATION_LOCATION,
+  ANNOTATION_ORIGIN_LOCATION,
+} from '@backstage/catalog-model';
 
 // A processor that reads from the RHDH RHOAI Bridge
 export class RHDHRHOAIReaderProcessor implements CatalogProcessor {
@@ -96,6 +100,21 @@ export class RHDHRHOAIReaderProcessor implements CatalogProcessor {
           data: item.data,
           location: { type: location.type, target: item.url },
         })) {
+          if (parseResult.type === 'entity') {
+            const locKey = `${location.type}:${location.target}`;
+            if (parseResult.entity.metadata.annotations === undefined) {
+              parseResult.entity.metadata.annotations = {
+                [ANNOTATION_LOCATION]: locKey,
+                [ANNOTATION_ORIGIN_LOCATION]: locKey,
+              };
+            } else {
+              parseResult.entity.metadata.annotations[ANNOTATION_LOCATION] =
+                locKey;
+              parseResult.entity.metadata.annotations[
+                ANNOTATION_ORIGIN_LOCATION
+              ] = locKey;
+            }
+          }
           parseResults.push(parseResult);
           emit(parseResult);
         }

--- a/workspaces/rhdh-ai/plugins/catalog-backend-module-rhdh-ai/src/providers/RHDHRHOAIEntityProvider.ts
+++ b/workspaces/rhdh-ai/plugins/catalog-backend-module-rhdh-ai/src/providers/RHDHRHOAIEntityProvider.ts
@@ -21,7 +21,11 @@ import type {
   SchedulerServiceTaskRunner,
   UrlReaderService,
 } from '@backstage/backend-plugin-api';
-import { LocationEntity } from '@backstage/catalog-model';
+import {
+  ANNOTATION_LOCATION,
+  ANNOTATION_ORIGIN_LOCATION,
+  LocationEntity,
+} from '@backstage/catalog-model';
 import {
   EntityProvider,
   EntityProviderConnection,
@@ -181,6 +185,19 @@ export class RHDHRHOAIEntityProvider implements EntityProvider {
                 const locType = loc.spec.type;
                 const locTarget = loc.spec.target;
                 const locKey = `${locType}:${locTarget}`;
+                if (resultEntity.entity.metadata.annotations === undefined) {
+                  resultEntity.entity.metadata.annotations = {
+                    [ANNOTATION_LOCATION]: locKey,
+                    [ANNOTATION_ORIGIN_LOCATION]: locKey,
+                  };
+                } else {
+                  resultEntity.entity.metadata.annotations[
+                    ANNOTATION_LOCATION
+                  ] = locKey;
+                  resultEntity.entity.metadata.annotations[
+                    ANNOTATION_ORIGIN_LOCATION
+                  ] = locKey;
+                }
                 const deferredEntity = {
                   entity: resultEntity.entity,
                   locationKey: locKey,


### PR DESCRIPTION
## Hey, I just made a Pull Request!

While working on https://issues.redhat.com/browse/RHDHPAI-641 I finally got around to adding the location annotations to the entities dynamically pushed from the bridge to our catalog processor.

Like we were doing in the configured locations processed on startup over at https://github.com/redhat-ai-dev/rhdh-plugins/blob/6b0c4a21c1cdfeba4cf2618d4aabadff544c7efc/workspaces/rhdh-ai/plugins/catalog-backend-module-rhdh-ai/src/providers/ModelCatalogResourceEntityProvider.ts#L151-L161 

While the lack of setting this annotation did not hinder the original POC demo (we just got some warning logs on the backstage process), while working on RHDHPAI-641 I discovered that if these annotations were not set, deleting the location did not delete the entities brought in by the location.  

Running this locally, I confirmed the deletion of the location does now in fact delete the associated entities.

@johnmcollier FYI