### PR TITLE
[RHDHPAI-609] Add generator functions for Model Catalog entities

### DIFF
--- a/workspaces/rhdh-ai/plugins/catalog-backend-module-rhdh-ai/package.json
+++ b/workspaces/rhdh-ai/plugins/catalog-backend-module-rhdh-ai/package.json
@@ -31,6 +31,7 @@
     "@backstage/plugin-catalog-backend": "^1.30.0",
     "@backstage/plugin-catalog-common": "^1.1.3",
     "@backstage/plugin-catalog-node": "^1.15.1",
+    "@redhat-ai-dev/model-catalog-types": "^1.0.1",
     "yaml": "^2.7.0"
   },
   "devDependencies": {

--- a/workspaces/rhdh-ai/plugins/catalog-backend-module-rhdh-ai/src/clients/ModelCatalogGenerator.test.ts
+++ b/workspaces/rhdh-ai/plugins/catalog-backend-module-rhdh-ai/src/clients/ModelCatalogGenerator.test.ts
@@ -1,0 +1,237 @@
+/*
+ * Copyright Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { GenerateCatalogEntities } from './ModelCatalogGenerator';
+import { Entity, ComponentEntity, ApiEntity } from '@backstage/catalog-model';
+import { ModelCatalog } from '@redhat-ai-dev/model-catalog-types';
+
+// ts-jest throws a module import error when pulling in enums defined in *.d.ts files
+// https://github.com/kulshekhar/ts-jest/issues/1229 - but our generator throws the enum in there, so we don't have the option to move it
+// Mocking the Type enum should be sufficient for these test cases
+enum Type {
+  Asyncapi = 'asyncapi',
+  Graphql = 'graphql',
+  Grpc = 'grpc',
+  Openapi = 'openapi',
+}
+
+describe('Model Catalog Generator', () => {
+  it('should generate catalog entities from a single model with defaults', () => {
+    const modelCatalog: ModelCatalog = {
+      models: [
+        {
+          name: 'ibm-granite',
+          description: 'IBM Granite code model',
+          lifecycle: 'production',
+          owner: 'example-user',
+        },
+      ],
+    };
+    const modelCatalogEntities = GenerateCatalogEntities(modelCatalog);
+    expect(modelCatalogEntities.length).toEqual(1);
+
+    const expectedModelEntities: Entity[] = [
+      {
+        apiVersion: 'backstage.io/v1beta1',
+        kind: 'Resource',
+        metadata: {
+          name: 'ibm-granite',
+          description: 'IBM Granite code model',
+          tags: [],
+          links: [],
+        },
+        spec: {
+          dependencyOf: [],
+          owner: 'example-user',
+          type: 'ai-model',
+        },
+      },
+    ];
+    expect(modelCatalogEntities).toEqual(expectedModelEntities);
+  });
+  it('should generate catalog entities for multiple models and a model server with API', () => {
+    const modelCatalog: ModelCatalog = {
+      modelServer: {
+        name: 'developer-model-service',
+        owner: 'example-user',
+        description: 'Developer model service running on vLLM',
+        homepageURL: 'https://example.com',
+        tags: ['vLLM', 'granite', 'ibm'],
+        API: {
+          url: 'https://api.example.com',
+          type: Type.Openapi,
+          spec: 'https://raw.githubusercontent.com/redhat-ai-dev/model-catalog-example/refs/heads/main/developer-model-service/openapi.json',
+          tags: ['openapi', 'openai', '3scale'],
+        },
+        lifecycle: 'production',
+      },
+      models: [
+        {
+          name: 'ibm-granite-20b',
+          description: 'IBM Granite 20b model running on vLLM',
+          artifactLocationURL:
+            'https://huggingface.co/ibm-granite/granite-20b-code-instruct',
+          tags: ['IBM', 'granite', 'vllm', '20b'],
+          owner: 'example-user',
+          lifecycle: 'production',
+        },
+        {
+          name: 'mistral-7b',
+          description: 'Mistral 7b model running on vLLM',
+          artifactLocationURL:
+            'https://huggingface.co/mistralai/Mistral-7B-Instruct-v0.2',
+          tags: ['mistralai', 'mistral', 'vllm', '7b'],
+          owner: 'example-user',
+          lifecycle: 'production',
+        },
+        {
+          name: 'gemma-2-2b',
+          description: 'Google Gemma 2 2b model running on vLLM',
+          artifactLocationURL: 'https://huggingface.co/google/gemma-2-2b',
+          howToUseURL: 'https://example.com/gemma',
+          tags: ['google', 'gemma'],
+          owner: 'example-user',
+          lifecycle: 'production',
+        },
+      ],
+    };
+    const modelCatalogEntities = GenerateCatalogEntities(modelCatalog);
+    expect(modelCatalog.modelServer !== undefined).toBe(true);
+    expect(modelCatalog.models.length).toBe(3);
+
+    const expectedModelEntities: Entity[] = [
+      {
+        apiVersion: 'backstage.io/v1beta1',
+        kind: 'Resource',
+        metadata: {
+          name: 'ibm-granite-20b',
+          description: 'IBM Granite 20b model running on vLLM',
+          tags: ['IBM', 'granite', 'vllm', '20b'],
+          links: [
+            {
+              url: 'https://huggingface.co/ibm-granite/granite-20b-code-instruct',
+              title: 'Artifact Location',
+            },
+          ],
+        },
+        spec: {
+          owner: 'example-user',
+          type: 'ai-model',
+          dependencyOf: ['component:developer-model-service'],
+        },
+      },
+      {
+        apiVersion: 'backstage.io/v1beta1',
+        kind: 'Resource',
+        metadata: {
+          name: 'mistral-7b',
+          description: 'Mistral 7b model running on vLLM',
+          tags: ['mistralai', 'mistral', 'vllm', '7b'],
+          links: [
+            {
+              url: 'https://huggingface.co/mistralai/Mistral-7B-Instruct-v0.2',
+              title: 'Artifact Location',
+            },
+          ],
+        },
+        spec: {
+          owner: 'example-user',
+          type: 'ai-model',
+          dependencyOf: ['component:developer-model-service'],
+        },
+      },
+      {
+        apiVersion: 'backstage.io/v1beta1',
+        kind: 'Resource',
+        metadata: {
+          name: 'gemma-2-2b',
+          description: 'Google Gemma 2 2b model running on vLLM',
+          tags: ['google', 'gemma'],
+          links: [
+            {
+              url: 'https://huggingface.co/google/gemma-2-2b',
+              title: 'Artifact Location',
+            },
+            {
+              url: 'https://example.com/gemma',
+              title: 'How to use',
+            },
+          ],
+        },
+        spec: {
+          owner: 'example-user',
+          type: 'ai-model',
+          dependencyOf: ['component:developer-model-service'],
+        },
+      },
+    ];
+    const expectedModelServerEntity: ComponentEntity = {
+      apiVersion: 'backstage.io/v1beta1',
+      kind: 'Component',
+      metadata: {
+        name: 'developer-model-service',
+        description: 'Developer model service running on vLLM',
+        tags: ['vLLM', 'granite', 'ibm'],
+        links: [
+          {
+            url: 'https://api.example.com',
+            title: 'API',
+          },
+          {
+            url: 'https://example.com',
+            title: 'Homepage',
+          },
+        ],
+      },
+      spec: {
+        type: 'model-server',
+        lifecycle: 'production',
+        owner: 'example-user',
+        dependsOn: [
+          'resource:ibm-granite-20b',
+          'resource:mistral-7b',
+          'resource:gemma-2-2b',
+        ],
+        providesApis: ['developer-model-service'],
+      },
+    };
+
+    const expectedModelServerAPIEntity: ApiEntity = {
+      apiVersion: `backstage.io/v1beta1`,
+      kind: `API`,
+      metadata: {
+        name: 'developer-model-service',
+        tags: ['openapi', 'openai', '3scale'],
+        links: [
+          {
+            url: `https://api.example.com`,
+            title: `API`,
+          },
+        ],
+      },
+      spec: {
+        type: 'openapi',
+        owner: 'example-user',
+        lifecycle: 'production',
+        definition:
+          'https://raw.githubusercontent.com/redhat-ai-dev/model-catalog-example/refs/heads/main/developer-model-service/openapi.json',
+      },
+    };
+    const expectedEntities: Entity[] = expectedModelEntities;
+    expectedEntities.push(expectedModelServerEntity);
+    expectedEntities.push(expectedModelServerAPIEntity);
+    expect(modelCatalogEntities).toEqual(expectedModelEntities);
+  });
+});

--- a/workspaces/rhdh-ai/plugins/catalog-backend-module-rhdh-ai/src/clients/ModelCatalogGenerator.ts
+++ b/workspaces/rhdh-ai/plugins/catalog-backend-module-rhdh-ai/src/clients/ModelCatalogGenerator.ts
@@ -1,0 +1,195 @@
+/*
+ * Copyright Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import {
+  ModelCatalog,
+  Model,
+  ModelServer,
+  API,
+} from '@redhat-ai-dev/model-catalog-types';
+import {
+  Entity,
+  ComponentEntity,
+  ApiEntity,
+  ResourceEntity,
+} from '@backstage/catalog-model';
+
+function isModelCatalog(o: any): o is ModelCatalog {
+  return 'model' in o && 'modelServer' in o;
+}
+
+export function ParseCatalogJSON(jsonStr: string): ModelCatalog {
+  const modelCatalog: ModelCatalog = JSON.parse(jsonStr);
+  if (isModelCatalog(modelCatalog)) {
+    // do something with now correctly typed object
+    return modelCatalog;
+  }
+  throw new Error(`model catalog JSON in unexpected format: ${jsonStr}`);
+}
+
+// Generate the Backstage catalog entities that correspond to the given model catalog json object
+// Note: These entities will need to have their location and origin location annotations set before ingestion into the catalog
+export function GenerateCatalogEntities(modelCatalog: ModelCatalog): Entity[] {
+  // Generate the Resource entities for the Model(s)
+  let modelCatalogEntities: Entity[] = [];
+  const models: Model[] = modelCatalog.models;
+  modelCatalogEntities = modelCatalogEntities.concat(
+    GenerateModelResourceEntities(models, modelCatalog.modelServer),
+  );
+
+  // Generate the Model Server and Model Server APi entity, if present
+  if (modelCatalog.modelServer !== undefined) {
+    const modelServer = modelCatalog.modelServer;
+    modelCatalogEntities.push(
+      GenerateModelServerComponentEntity(modelServer, modelCatalog.models),
+    );
+
+    // If there's an exposed API present, generate that entity as well, and update the model server entity accordingly
+    if (modelServer.API !== undefined) {
+      const api: API = modelServer.API;
+      modelCatalogEntities.push(GenerateModelServerAPI(api, modelServer));
+    }
+  }
+
+  return modelCatalogEntities;
+}
+
+export function GenerateModelResourceEntities(
+  models: Model[],
+  modelServer?: ModelServer,
+): ResourceEntity[] {
+  const modelResourceEntities: ResourceEntity[] = [];
+  models.forEach(model => {
+    const modelResourceEntity: ResourceEntity = {
+      apiVersion: 'backstage.io/v1beta1',
+      kind: 'Resource',
+      metadata: {
+        name: `${model.name}`,
+        description: `${model.description}`,
+        tags: [],
+        links: [],
+      },
+      spec: {
+        owner: `${model.owner}`,
+        type: 'ai-model',
+      },
+    };
+
+    // Set optional parameters, if present
+    if (model.tags !== undefined) {
+      modelResourceEntity.metadata.tags = model.tags;
+    }
+    if (model.artifactLocationURL !== undefined) {
+      modelResourceEntity.metadata.links?.push({
+        title: 'Artifact Location',
+        url: `${model.artifactLocationURL}`,
+      });
+    }
+    if (model.howToUseURL !== undefined) {
+      modelResourceEntity.metadata.links?.push({
+        title: 'How to use',
+        url: `${model.howToUseURL}`,
+      });
+    }
+    modelResourceEntity.spec.dependencyOf = [];
+    if (modelServer !== undefined) {
+      modelResourceEntity.spec.dependencyOf?.push(
+        `component:${modelServer.name}`,
+      );
+    }
+    modelResourceEntities.push(modelResourceEntity);
+  });
+
+  return modelResourceEntities;
+}
+
+export function GenerateModelServerComponentEntity(
+  modelServer: ModelServer,
+  models: Model[],
+): ComponentEntity {
+  const modelServerComponent: ComponentEntity = {
+    apiVersion: 'backstage.io/v1beta1',
+    kind: 'Component',
+    metadata: {
+      name: `${modelServer.name}`,
+      description: `${modelServer.description}`,
+      tags: [],
+      links: [],
+    },
+    spec: {
+      type: 'model-server',
+      lifecycle: `${modelServer.lifecycle}`,
+      owner: `${modelServer.owner}`,
+    },
+  };
+
+  // Add the models to the model server as dependants
+  modelServerComponent.spec.dependsOn = [];
+  models.forEach(model => {
+    modelServerComponent.spec.dependsOn?.push(`resource:${model.name}`);
+  });
+
+  // Configure optional parameters
+  // Set optional parameters, if present
+  if (modelServer.tags !== undefined) {
+    modelServerComponent.metadata.tags = modelServer.tags;
+  }
+  modelServerComponent.metadata.links = [];
+  if (modelServer.API !== undefined) {
+    modelServerComponent.metadata.links.push({
+      title: `API`,
+      url: `${modelServer.API.url}`,
+    });
+    modelServerComponent.spec.providesApis = [modelServer.name];
+  }
+  if (modelServer.homepageURL !== undefined) {
+    modelServerComponent.metadata.links.push({
+      title: 'Homepage',
+      url: `${modelServer.homepageURL}`,
+    });
+  }
+  return modelServerComponent;
+}
+
+export function GenerateModelServerAPI(
+  api: API,
+  modelServer: ModelServer,
+): ApiEntity {
+  const modelServerAPIEntity: ApiEntity = {
+    apiVersion: `backstage.io/v1beta1`,
+    kind: `API`,
+    metadata: {
+      name: `${modelServer.name}`,
+      tags: [],
+      links: [
+        {
+          url: `${api.url}`,
+          title: `API`,
+        },
+      ],
+    },
+    spec: {
+      type: `${api.type}`,
+      owner: `${modelServer.owner}`,
+      lifecycle: `${modelServer.lifecycle}`,
+      definition: `${api.spec}`,
+    },
+  };
+
+  if (api.tags !== undefined) {
+    modelServerAPIEntity.metadata.tags = api.tags;
+  }
+  return modelServerAPIEntity;
+}

--- a/workspaces/rhdh-ai/yarn.lock
+++ b/workspaces/rhdh-ai/yarn.lock
@@ -10179,9 +10179,17 @@ __metadata:
     "@backstage/plugin-catalog-backend": ^1.30.0
     "@backstage/plugin-catalog-common": ^1.1.3
     "@backstage/plugin-catalog-node": ^1.15.1
+    "@redhat-ai-dev/model-catalog-types": ^1.0.1
     yaml: ^2.7.0
   languageName: unknown
   linkType: soft
+
+"@redhat-ai-dev/model-catalog-types@npm:^1.0.1":
+  version: 1.0.1
+  resolution: "@redhat-ai-dev/model-catalog-types@npm:1.0.1"
+  checksum: 6b85d92c85f34d675168ad1bebf1b48f015c5fe59f235f06a0d8e7271f5415e25e40cbe1d5eecf03ada85be8214f09353f1987a316f97b9d681e4ef6d32102de
+  languageName: node
+  linkType: hard
 
 "@redis/bloom@npm:1.2.0":
   version: 1.2.0


### PR DESCRIPTION
## Hey, I just made a Pull Request!

Closes https://issues.redhat.com/browse/RHDHPAI-609

Adds generator functions to the backend plugin to enable it to generate catalog entities from the Model Catalog JSON objects:
- `GenerateCatalogEntities`: Returns an array of Entity objects corresponding to the Models, Model Server, and API expressed in the JSON
- `GenerateModelResourceEntities`: Returns just the model resource entity objects
- `GenerateModelServerComponentEntity`: Returns just the model server component entity object
- `GenerateModelServerAPI`: Returns just the model server API entity

I opted not to publish these in a separate npm module as I think the primary consumer of these will be the RHDH plugin for the time being, and colocating the generator functions with the plugin reduces the overhead when updating the generator.

I also started to add a couple _very_ basic tests, which are by no means exhaustive, but should be a good starting point.
#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [ ] A changeset describing the change and affected packages. ([more info](https://github.com/redhat-developer/rhdh-plugins/blob/main/CONTRIBUTING.md#creating-changesets))
- [ ] Added or Updated documentation
- [x] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
